### PR TITLE
Fix for links to local images (file:/// -> file://)

### DIFF
--- a/md_image.py
+++ b/md_image.py
@@ -179,7 +179,13 @@ class ImageHandler:
                     debug("Failed to load {}:".format(path), e)
                     continue
                 img = urllib.parse.urlunparse(url)
-                img = img.replace('file:///', 'file://', 1)
+
+                # On Windows, urlunparse adds a third slash after 'file://' for some reason
+                # This breaks the image url, so it must be removed
+                # splitdrive() detects windows because it only returns something if the
+                # path contains a drive letter
+                if os.path.splitdrive(path)[0]:
+                    img = img.replace('file:///', 'file://', 1)
 
             if not ttype:
                 debug("unknown ttype")

--- a/md_image.py
+++ b/md_image.py
@@ -179,6 +179,7 @@ class ImageHandler:
                     debug("Failed to load {}:".format(path), e)
                     continue
                 img = urllib.parse.urlunparse(url)
+                img = img.replace('file:///', 'file://', 1)
 
             if not ttype:
                 debug("unknown ttype")


### PR DESCRIPTION
On Windows (I have not checked on other OSes), the path that MarkdownImages generates for local images is something like *file:///C:\...\image.png*.
This path is inserted in the html generated for the phantom to display the image.
But the result is a "broken link" image appearing in sublime (with the dimensions of the original image).
The culprit is the third / after 'file'. Removing it fixes the issue and makes the image load correctly.