### PR TITLE
Add base_path setting

### DIFF
--- a/MarkdownImages.sublime-settings
+++ b/MarkdownImages.sublime-settings
@@ -17,4 +17,10 @@
 
     // set to true if you want remote images to display on_post_save
     "show_remote_images_on_post_save": false,
+
+    // A base path to images.
+    // Let's say you store your images in `/attachments` folder.
+    // And inside that folder you have `foo.png`. Set this to `/attachments`
+    // to be able to use ![](foo.png) without specifying the full path.
+    "base_path": "",
 }

--- a/md_image.py
+++ b/md_image.py
@@ -66,11 +66,13 @@ class MarkdownImagesPlugin(sublime_plugin.EventListener):
 
     def _update_images(self, settings, view, **kwargs):
         max_width = settings.get('img_maxwidth', None)
+        base_path = settings.get('base_path', None)
         ImageHandler.hide_images(view)
         ImageHandler.show_images(view,
                                  max_width=max_width,
                                  show_local=kwargs.get('show_local', False),
-                                 show_remote=kwargs.get('show_remote', False))
+                                 show_remote=kwargs.get('show_remote', False),
+                                 base_path=base_path)
 
 
 class ImageHandler:
@@ -90,7 +92,7 @@ class ImageHandler:
         ImageHandler.urldata.pop(view.id(), None)
 
     @staticmethod
-    def show_images(view, max_width=None, show_local=True, show_remote=False):
+    def show_images(view, max_width=None, show_local=True, show_remote=False, base_path=""):
         debug("show_images")
         if not show_local and not show_remote:
             debug("doing nothing")
@@ -195,6 +197,12 @@ class ImageHandler:
                 # determined (e.g. if the view content is not in a project and
                 # hasn't been saved), then it will anchor to /.
                 path = url.path
+
+                # Force paths to be prefixed with base_path if it was provided
+                # in settings.
+                if base_path:
+                    path = os.path.join(base_path, path)
+
                 if not os.path.isabs(path):
                     folder = get_path_for(view)
                     path = os.path.join(folder, path)
@@ -376,10 +384,12 @@ class MarkdownImagesShowCommand(sublime_plugin.TextCommand):
         max_width = settings.get('img_maxwidth', None)
         show_local = kwargs.get('show_local', True)
         show_remote = kwargs.get('show_remote', False)
+        base_path = settings.get('base_path', None)
         ImageHandler.show_images(self.view,
                                  show_local=show_local,
                                  show_remote=show_remote,
-                                 max_width=max_width)
+                                 max_width=max_width,
+                                 base_path=base_path)
 
 
 class MarkdownImagesHideCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
Closes #3.

I added a new setting - `base_path`. It can be used to reference images from a fixed location. 

For example, I have my notes organized in such a way, that all attachments are inside `/path/to/attachments` folder in the project. When I want to reference an attachment, I don't have to specify the full path or mangle around with a relative path. I can just put `![](foo_bar.png)`. It will effectively expand to `/path/to/attachments/foo_bar.png`.

This behavior is somewhat popular these days because of [Obsidian.md](https://obsidian.md/) and the likes of it.

I tested my changes with `qa-test-cases.md`. I am also using the forked version with my notes.