### PR TITLE
Fix opening preferences

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -16,64 +16,21 @@
                         "children":
                         [
                             {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/MarkdownImages/MarkdownImages.sublime-settings"},
-                                "caption": "Settings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/User/MarkdownImages.sublime-settings"},
-                                "caption": "Settings – User"
-                            },
-                            {
-                                "command": "open_file",
+                                "command": "edit_settings",
                                 "args": {
-                                    "file": "${packages}/MarkdownImages/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – Default"
+                                     "base_file": "${packages}/Markdown Images/MarkdownImages.sublime-settings",
+                                     "default": "{\n\t$0\n}\n"
+                                 },
+                                "caption": "Settings",
                             },
                             {
-                                "command": "open_file",
+                                "command": "edit_settings",
                                 "args": {
-                                    "file": "${packages}/MarkdownImages/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
+                                    "base_file": "${packages}/Markdown Images/Default ($platform).sublime-keymap",
+                                    "default": "// Settings in here override those in \"Markdown Images/Default.sublime-settings\",\n\n{\n\t$0\n}\n"
                                 },
-                                "caption": "Key Bindings – Default"
+                                "caption": "Key Bindings",
                             },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/MarkdownImages/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            { "caption": "-" }
                         ]
                     }
                 ]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ If the URI points to a file on disk, it is called a "local" image, and renders b
 
 You can choose to show local, show remote or show all images from the [command palette](#commands) and with the [configuration](#configuration) settings.
 
+## Installation
+
+You can install this package using [Package Control](https://packagecontrol.io/installation) using the name “Markdown Images”.
+
+For development, you will want to clone the repository into “Markdown Images” directory in the Sublime Text’s `Packages` directory (`Preferences` → `Browse Packages…`):
+
+```
+git clone git@github.com:xsleonard/sublime-MarkdownImages.git 'Markdown Images'
+```
+
+(Or create a symlink with such name from your projects directory.)
+
 ## Configuration
 
 By default, images are rendered when the file is first loaded. This can be configured with the `show_local_images_on_load` and `show_remote_images_on_load` settings.


### PR DESCRIPTION
When installing the package using Package Control, the package name would be “Markdown Images”, preventing the Settings menu item from working. Unfortunately, fixing that will break it for local checkouts.

While at it, let’s also use the modern `edit_settings` command, available since Sublime Text 3116.
