### PR TITLE
Adding a Config Option to remove ? arguments from local images

### DIFF
--- a/MarkdownImages.sublime-settings
+++ b/MarkdownImages.sublime-settings
@@ -18,6 +18,9 @@
     // set to true if you want remote images to display on_post_save
     "show_remote_images_on_post_save": false,
 
+    // set to true if you want remove arguments from filenames like image.png?resize=800
+    "remove_local_url_arguments": false,
+
     // A base path to images.
     // Let's say you store your images in `/attachments` folder.
     // And inside that folder you have `foo.png`. Set this to `/attachments`

--- a/md_image.py
+++ b/md_image.py
@@ -67,12 +67,14 @@ class MarkdownImagesPlugin(sublime_plugin.EventListener):
     def _update_images(self, settings, view, **kwargs):
         max_width = settings.get('img_maxwidth', None)
         base_path = settings.get('base_path', None)
+        arg_trim = settings.get('remove_local_url_arguments', None)
         ImageHandler.hide_images(view)
         ImageHandler.show_images(view,
                                  max_width=max_width,
                                  show_local=kwargs.get('show_local', False),
                                  show_remote=kwargs.get('show_remote', False),
-                                 base_path=base_path)
+                                 base_path=base_path,
+                                 arg_trim=arg_trim)
 
 
 class ImageHandler:
@@ -92,7 +94,7 @@ class ImageHandler:
         ImageHandler.urldata.pop(view.id(), None)
 
     @staticmethod
-    def show_images(view, max_width=None, show_local=True, show_remote=False, base_path=""):
+    def show_images(view, max_width=None, show_local=True, show_remote=False, base_path="", arg_trim=False):
         debug("show_images")
         if not show_local and not show_remote:
             debug("doing nothing")
@@ -224,6 +226,11 @@ class ImageHandler:
                     debug("Failed to load {}:".format(path), e)
                     continue
                 img = urllib.parse.urlunparse(url)
+
+                # Removes arguments in the URL
+                if arg_trim:
+                    img = img.split('?')[0]
+                    debug("split")
 
                 # On Windows, urlunparse adds a third slash after 'file://' for some reason
                 # This breaks the image url, so it must be removed
@@ -403,11 +410,13 @@ class MarkdownImagesShowCommand(sublime_plugin.TextCommand):
         show_local = kwargs.get('show_local', True)
         show_remote = kwargs.get('show_remote', False)
         base_path = settings.get('base_path', None)
+        arg_trim = settings.get('remove_local_url_arguments', None)
         ImageHandler.show_images(self.view,
                                  show_local=show_local,
                                  show_remote=show_remote,
                                  max_width=max_width,
-                                 base_path=base_path)
+                                 base_path=base_path,
+                                 arg_trim=arg_trim)
 
 
 class MarkdownImagesHideCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
*This is baby's first pull request, I'm new to this*

Had an issue browsing my grav blog posts with sublime text and this plugin. Grav allows you to format images like `image.png?lightbox&resize=800` but that of course doesn't work when browsing the markdown file locally. This change simply cuts off any ? arguments for local files. While I can't see how this could possibly interfere with any expected behavior with local file operations, I made it a config option just in case.