### PR TITLE
Improvements

### DIFF
--- a/MarkdownImages.sublime-settings
+++ b/MarkdownImages.sublime-settings
@@ -23,4 +23,8 @@
     // And inside that folder you have `foo.png`. Set this to `/attachments`
     // to be able to use ![](foo.png) without specifying the full path.
     "base_path": "",
+
+    // Base zoom to be applied to the images.
+    // Multiplicative with image's attribute `zoom`.
+    "base_zoom": 1.0,
 }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a Sublime Text 3 plugin to render images inside of markdown files.
 Images in markdown use the `![alt text](uri)` markup. Wherever this appears, this plugin can render the image specified by the URI below the line.
 
 You can configure an image's dimensions by adding HTML `<img>` properties after the image markup: `![alt text](uri){width="200", height="200"}`. Everything between the `{}` will be copied to the `<img>` element that renders the image.
+Alternatively you can specify `zoom` tag: `{zoom="1.5"}` and the multiplicative zoom factor will be applied on top of the `base_zoom` config variable.
 
 If the URI points to a file on disk, it is called a "local" image, and renders by default. If the URI points to an external (http, https, etc) resource, it is called a "remote" image, and does not render by default.
 

--- a/md_image.py
+++ b/md_image.py
@@ -338,7 +338,7 @@ def check_imgattr(view, line_region, link_region=None):
     return zoom, width, height, imgattr
 
 def cut_attr(imgattr, attr):
-    m = re.search(attr+r'=\"(\d+.?\d*)\"', imgattr)
+    m = re.search(attr+r'\s*=\s*\"?(\d+(\.\d+)?)\"?', imgattr)
     if m:
         try:
             val = float(m.groups()[0])


### PR DESCRIPTION
I extracted 2 useful commits from other forks with some modifications:

- https://github.com/eduard-netsajev/sublime-MarkdownImages/commit/ec312110d59b4462f7e7e14f57415762f4f219fe
- https://github.com/michaelomichael/sublime-MarkdownImages/commit/0293964878ffe8ee40b2ed0336a186998522b6ca

New features:

- `zoom` attribute and `base_zoom` setting
- Width/height automatically calculated when only one of them is provided
- Images are now clickable (works for both URL and local files)
- Attribute definitions are now more flexible (whitespaces allowed etc.)