### PR TITLE
Fix exceptions for scratch views

### DIFF
--- a/md_image.py
+++ b/md_image.py
@@ -58,10 +58,12 @@ class MarkdownImagesPlugin(sublime_plugin.EventListener):
         ImageHandler.on_close(view)
 
     def _should_run_for_extension(self, settings, view):
-        extensions = settings.get('extensions')
-        fn = view.file_name()
-        _, ext = os.path.splitext(fn)
+        file_name = view.file_name()
+        if not file_name:
+            return False
+        _, ext = os.path.splitext(file_name)
         # extensions can be either a list or single string
+        extensions = settings.get('extensions')
         if isinstance(extensions, str):
             return ext == extensions
         return ext in extensions


### PR DESCRIPTION
This PR teaches `_should_run_for_extension()` to return False without complaints, if `view.file_name()` returns `None` for new views with unsaved content.